### PR TITLE
Typo corrected and Added template

### DIFF
--- a/clara-agent/models/create_clara_twitter_model.mjs
+++ b/clara-agent/models/create_clara_twitter_model.mjs
@@ -1,16 +1,25 @@
-import ollama from 'ollama'
-import {CLARA_TWITTER_SYSTEM} from "../systems/clara_systems.mjs";
-import {BASE_MODEL, CLARA_MARKET_MODEL, CLARA_TWITTER_MODEL} from "../constatns.mjs";
-import {TEMPLATE} from "./template.mjs";
+import ollama from 'ollama';
+import { CLARA_TWITTER_SYSTEM } from '../systems/clara_systems.mjs';
+import { BASE_MODEL, CLARA_TWITTER_MODEL } from '../constants.mjs';
+import { TEMPLATE } from './template.mjs';
 
-await ollama.delete({
-  model: CLARA_TWITTER_MODEL
-});
+async function recreateModel() {
+  try {
+    console.log(`Deleting model: ${CLARA_TWITTER_MODEL}...`);
+    await ollama.delete({ model: CLARA_TWITTER_MODEL });
 
-await ollama.create(
-  {
-    model: CLARA_TWITTER_MODEL,
-    from: BASE_MODEL,
-    system: CLARA_TWITTER_SYSTEM,
-    /*template: TEMPLATE*/
-  });
+    console.log(`Creating model: ${CLARA_TWITTER_MODEL} from ${BASE_MODEL}...`);
+    await ollama.create({
+      model: CLARA_TWITTER_MODEL,
+      from: BASE_MODEL,
+      system: CLARA_TWITTER_SYSTEM,
+      template: TEMPLATE
+    });
+
+    console.log(`Model ${CLARA_TWITTER_MODEL} successfully recreated.`);
+  } catch (error) {
+    console.error('Error while recreating model:', error);
+  }
+}
+
+await recreateModel();


### PR DESCRIPTION
1) Fixed typo
Was: import {BASE_MODEL, CLARA_MARKET_MODEL, CLARA_TWITTER_MODEL} from "../constatns.mjs";
Now: import { BASE_MODEL, CLARA_TWITTER_MODEL } from '../constants.mjs';

2) Added template: 
In the original code, the line with template was cut off and it was not used. Now it is added to create.

